### PR TITLE
FIX: Promise should be save before dispatching jobs

### DIFF
--- a/src/Jobs/Promise.php
+++ b/src/Jobs/Promise.php
@@ -89,8 +89,8 @@ abstract class Promise implements ShouldQueue, MayPromised, NowDispatchingJob
         $this->ensureFinishConditionsConfigured();
 
         if ($this->promise_type === self::PROMISE_TYPE_SYNC) {
-            $this->dispatchJob(reset($this->promise_jobs));
             $this->save();
+            $this->dispatchJob(reset($this->promise_jobs));
 
             return;
         }


### PR DESCRIPTION
Promise should be save before dispatching jobs

If queue driver is **sync** promise wont be able to continue dispatching jobs, as there are none in db